### PR TITLE
Allow the user to include the .sql3 suffix in URLs

### DIFF
--- a/doc/analysis.mdwn
+++ b/doc/analysis.mdwn
@@ -137,8 +137,8 @@ the report via some url like:
 
 can be used to open and view the report. The sqlite data file always
 needs to be in a subdirectory "data" of the place where the igprof-navigator 
-script is located. The filename extension should be ".sql3", even if the URL
-will specify the sqlite filename without the extension. The $PATHTOCGIAREA
+script is located. The filename extension should be ".sql3", although the URL
+is allowed to omit the extension. The $PATHTOCGIAREA
 and "http://yoursite/x/y/z/cgi-bin/" will of course depend on the
 precise details of the site where you are working.
 
@@ -166,6 +166,8 @@ and copy in the sqlite file:
 The URL to the report will then be:
 
     http://cern.ch/<username>/cgi-bin/igprof-navigator/foo_perf/
+or
+    http://cern.ch/<username>/cgi-bin/igprof-navigator/foo_perf.sql3/
 
 Note that it is also possible (in any site, not just CERN) to create
 subdirectories under the "data" directory

--- a/src/igprof-navigator
+++ b/src/igprof-navigator
@@ -201,6 +201,7 @@ def summary(database, out, cumulative):
   out.write(CSS)
   if absPath != ".":
     dummy, arch, ib, f = rsplit(absPath, "/", 3)
+    f = re.sub(r"\.sql3$", "", f)
     out.write("""<body>
                  <h1>%s - %s, %s</h1><a href="../">
                   Back to profiles index</a>
@@ -758,10 +759,12 @@ border-style: dashed;
 
 # Produces a list of possible database paths.
 # The only two possibilities for a url are "<script>/<database-path>"
-# or "<script>/<database-path>/<rank>" and the database can only be in
-# <database-path> + ".sql3"
+# or "<script>/<database-path>/<rank>" and the database can only be
+# <database-path> or <database-path> + ".sql3"
 def possibleDBAndRanks(p):
+  yield ("", p)
   yield ("", p.rstrip("/") + ".sql3")
+  yield (basename(p), dirname(p))
   yield (basename(p), dirname(p).rstrip("/") + ".sql3")
 
 # Main logic to generate CGI pages. 


### PR DESCRIPTION
It seems to confuse people that they aren't allowed to use the full filename
