### PR TITLE
Do not have debug printout if stderr is closed.

### DIFF
--- a/src/profile-finstrument.cc
+++ b/src/profile-finstrument.cc
@@ -99,7 +99,7 @@ do_exit ()
       return;
 
     depth = IgHookTrace::stacktrace(addresses, IgProfTrace::MAX_DEPTH);
-     
+
     frame = buf->push(addresses+1, depth-1);
     buf->tick(frame, &s_ct_time, diff, 1);
     buf->tick(frame, &s_ct_calls, 1, 1);

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -35,7 +35,7 @@ HIDDEN bool             s_igprof_activated = false;
 HIDDEN IgProfAtomic     s_igprof_enabled = 0;
 HIDDEN pthread_key_t    s_igprof_bufkey;
 HIDDEN pthread_key_t    s_igprof_flagkey;
-
+HIDDEN int              s_igprof_stderrOpen = true;
 // -------------------------------------------------------------------
 // Used to capture real user start arguments in our custom thread wrapper
 struct HIDDEN IgProfWrappedArg
@@ -653,7 +653,7 @@ igprof_debug(const char *format, ...)
   int out = 0;
   int len;
 
-  if (debugging)
+  if (debugging && s_igprof_stderrOpen)
   {
     timeval tv;
     gettimeofday(&tv, 0);

--- a/src/profile.h
+++ b/src/profile.h
@@ -12,6 +12,7 @@ extern bool             s_igprof_activated;
 extern IgProfAtomic     s_igprof_enabled;
 extern pthread_key_t    s_igprof_bufkey;
 extern pthread_key_t    s_igprof_flagkey;
+extern int              s_igprof_stderrOpen;
 extern void             (*igprof_abort) (void) __attribute__((noreturn));
 extern char *           (*igprof_getenv) (const char *);
 extern int              (*igprof_unsetenv) (const char *);


### PR DESCRIPTION
If the profiled program closes stderr stream the igprof_debug got to be disabled
to avoid garbling the output which end up reusing the closed file descriptor.
