### PR TITLE
New x86 instruction length decoder.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ ADD_LIBRARY(igprof SHARED
             src/trace.cc
             src/trace-mem.cc
             src/trace-mmap.cc
-            src/trace-throw.cc)
+            src/trace-throw.cc
+            src/instruction.cc)
 #SET_TARGET_PROPERTIES(igprof PROPERTIES LINK_FLAGS -Wl,-z,nodefs)
 TARGET_LINK_LIBRARIES(igprof ${UNWIND_LIBRARY} ${IGPROF_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 ADD_EXECUTABLE(igprof-analyse src/analyse.cc)

--- a/src/instruction.cc
+++ b/src/instruction.cc
@@ -1,0 +1,275 @@
+#include "instruction.h"
+#include "macros.h"
+
+Instruction::Instruction()
+{
+  immediate = 0;
+  length = 0;
+  vex1.encoded = 0;
+  modRM.encoded = 0;
+  patch = 0;
+  prologueSize = 0;
+}
+
+void Instruction::clear()
+{
+  immediate = 0;
+  length = 0;
+  vex1.encoded = 0;
+  modRM.encoded = 0;
+  patch = 0;
+  prologueSize = 0;  
+}
+
+// returns possible patches
+unsigned Instruction::getPatch(void)
+{
+  return patch;
+}
+
+// Takes a pointer to the begin of the instructions.
+// n is sum of previous instruction's the lengts. It is needed to make correct
+// patches for instructions that are relative to the instruction pointer
+// If 0 length returned the instruction couldn't be decoded or can not be moved.
+int Instruction::decodeInstruction(const void *sym, int n)
+{
+  prologueSize = n;
+  unsigned char *insns = (unsigned char *) sym;
+  int prefixes = decodePrefix(insns);
+  insns += prefixes;  
+  decodeOpcode(insns);
+  return length;
+}
+
+// Check possible instruction prefixes. Marks the prefix set and adds the
+// instruction length by one or in some cases by 5 if prefix is found and moves
+// to next index of the insns.
+int Instruction::decodePrefix(unsigned char *insns)
+{
+  int prefixes = 0;
+  char done = 0;
+  do
+  {
+    switch (*insns)
+    {
+      case 0xf0:
+      case 0xf2:
+      case 0xf3:
+      case 0x2e:
+      case 0x36:
+      case 0x3e:
+      case 0x26:
+      case 0x66:
+      case 0x67:
+        prefixes++;
+        length++;
+        insns++;
+        break;
+      case 0x64:
+      case 0x65:
+        prefixes++;
+        length += 5;
+        insns++;
+        break;
+      default:
+        done = 1;
+    }
+  } while (!done);
+
+  // REX prefix is always the last prefix
+  if ((*insns & 0xf0) == 0x40)
+  {
+    prefixes++;
+    length++;
+  }
+  return prefixes;
+}
+
+// Decodes the length of the instruction after prefixes.
+// First the function check which opcode lookup table entry (map) need to be
+// used. After the map selection, the opcode group is read from the map and
+// instruction length is decoded.
+void Instruction::decodeOpcode(unsigned char *insns)
+{
+  // Check select correct opcode map
+  int select_map;
+  switch (*insns)
+  {
+    case 0xf8:  // Pop Ev or XOP
+      modRM.encoded = insns[1];
+      if (modRM.bits.reg == 0)
+      {
+        evalModRM(insns[1]);
+        return;
+      }
+      else  // FIXME add support for XOP
+        length = 0;
+        return;
+    case 0xc4:  // 3 byte vex encoded
+      vex1.encoded = insns[1];
+      if (vex1.bits.map == 1)
+        select_map = 1;
+      else if (vex1.bits.map == 2)
+        select_map = 2;
+      else
+        select_map = 3;
+      length += 3;
+      insns += 3;
+      break;
+    case 0x0f:
+      if (insns[1] == 0x38) // 3 byte opcode
+      {
+        select_map = 2;
+        length += 2;
+        insns += 2;
+      }
+      else if (insns[1] == 0x3a) // 3 byte opcode
+      {
+        select_map = 3;
+        length += 2;
+        insns += 2;
+      }
+      else  // 2 byte opcode
+      {
+        select_map = 1;
+        length++;
+        insns++;
+      }
+      break;
+    case 0xc5:  // 2 byte vex encoded. (map b00001)
+      select_map = 1;
+      length += 2;
+      insns += 2;
+      break;
+    default:
+      select_map = 0;
+  }
+
+  int group = ins_lookup[select_map][*insns];
+  switch (group)
+  {
+    case 0:
+      length += 1;
+      break;
+    case 1:
+      length += 2;
+      break;
+    case 2:
+      length += 5;
+      break;
+    case 3:
+      evalModRM(insns[1]);
+      break;
+    case 4:
+      immediate = 1;
+      evalModRM(insns[1]);
+      break;
+    case 5:
+      immediate = 4;
+      evalModRM(insns[1]);
+      break;
+    case 6: //invalid
+      length = 0;
+      break;
+    case 7:
+      groupF6F7(insns);
+      break;
+    case 8:
+      length += 8;
+      evalModRM(insns[1]);
+      break;
+    case 9: // jmp 4byte off (need patch)
+      length += 5;
+      makePatch();
+      break;
+    case 10:
+      groupFF(insns);
+      break;
+    case 11:
+      group0F00(insns);
+      break;
+    case 12:
+      group3dNOW(insns);
+      break;
+    case 13:
+      groupSSE5A(insns);
+      break;
+  }
+}
+
+// Handles opcode groups 0xF6 and 0xF7
+void Instruction::groupF6F7(unsigned char *insns)
+{
+  modRM.encoded = insns[1];
+  if (modRM.bits.reg == 0 || modRM.bits.reg == 1)
+  {
+    if (*insns == 0xf6)
+      immediate = 1;
+    else
+      immediate = 4;
+  }
+  evalModRM(insns[1]);
+}
+
+// Handles opcode group 0xFF
+void Instruction::groupFF(unsigned char *insns)
+{
+  modRM.encoded = insns[1];
+  if (modRM.bits.reg == 0 || modRM.bits.reg == 1
+      || modRM.bits.reg == 6)
+    evalModRM(insns[1]);
+  else
+    length = 0;
+}
+
+//Handles opcode group 0x0F 0x00
+void Instruction::group0F00(unsigned char *insns)
+{
+  modRM.encoded = insns[1];
+  if (modRM.bits.reg != 6)
+    evalModRM(insns[1]);
+  else
+    length = 0;
+}
+
+// AMD old 3dNOW! instructions. Returns 0 as they are not
+// yet supported 
+void Instruction::group3dNOW(unsigned char *insns UNUSED)
+{
+  length = 0; //not yet supported
+}
+
+void Instruction::groupSSE5A(unsigned char *insns UNUSED)
+{
+  length = 0; //not yet supported
+}
+
+// Decode modRM byte and adds correct length and calls makepatch if needed
+void Instruction::evalModRM(unsigned char insns)
+{
+  modRM.encoded = insns;
+  //mod == 00 and rm == 5 opcode, modRM, rip + 32bit
+  //mod == 00 opcode, modRM,(SIB)
+  //mod == 01 opcode,modRM,(SIB),1 byte immediate
+  //mod == 10 opcode,modRM,(SIB),4 byte immeadiate
+  //mod == 11 opcode,modRM
+  if (modRM.bits.mod == 0 && modRM.bits.rm == 5)
+    makePatch();
+  else if (modRM.bits.mod == 0)
+    (modRM.bits.rm) != 4 ? length += 2 + immediate : length += 3 + immediate;
+  else if (modRM.bits.mod == 1)
+    (modRM.bits.rm) != 4 ? length += 3 + immediate : length += 4 + immediate;
+  else if (modRM.bits.mod == 2)
+    (modRM.bits.rm) != 4 ? length += 6 + immediate : length += 7 + immediate;
+  else
+    length += 2 + immediate;
+}
+
+// Creates patch for position relative instructions to allow relocating it.
+void Instruction::makePatch()
+{
+  int n = prologueSize + length;
+  int extra = modRM.encoded ? 1 : 0;
+  patch = (n+0x5 + extra + immediate)*0x100 + n + 1 + extra;
+  length += 5 + extra + immediate; 
+}

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -1,0 +1,162 @@
+#ifndef INSTRUCTION_H
+# define INSTRUCTION_H
+
+/* Instruction class is used to decode x86_64 instruction lengths. The
+   instructionsa re grouped together based on their characteristics. For example
+   instructions that need contains modRM byte and has no immediate byte are in
+   own group.
+
+   ins_lookup table has map where each opcode is assigned into some group. The
+   lookup table has 4 different maps */
+
+/* Opcode lookup tables:
+   0 == no modRM byte
+   1 == no modRM byte, one byte immediate
+   2 == no modRM byte, four byte immediate
+   3 == modRM byte
+   4 == modRM byte + 1 byte immediate
+   5 == modRM byte + 4 byte immediate
+   6 == invalid/not supported
+   7 == F6/F7 group (need to check modRM reg value)
+   8 == a0 a4
+   9 == jump 4byte off. Need patching
+  10 == group FF
+  11 == 0xf0 00 group
+  12 == 3DNow! instructions
+  13 == SSE5A AMD */
+  
+static const char ins_lookup[][256] = {  
+  // One byte opcode <op>
+  {3,3,3,3, 1,2,6,6, 3,3,3,3, 1,2,6,6,
+   3,3,3,3, 1,2,6,6, 3,3,3,3, 1,2,6,6,
+   3,3,3,3, 1,2,6,6, 3,3,3,3, 1,2,6,6,
+   3,3,3,3, 1,2,6,6, 3,3,3,3, 1,2,6,6,
+
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, // REX prefixes
+   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+   6,6,6,3, 6,6,6,6, 2,5,1,4, 6,6,6,6, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, // jump one byte off 
+
+   4,5,4,4, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+   0,0,0,0, 0,0,0,0, 0,0,6,0, 0,0,6,6, 
+   8,8,8,8, 0,0,0,0, 1,2,3,3, 3,3,3,3, 
+   1,1,1,1, 1,1,1,1, 2,2,2,2, 2,2,2,2, 
+
+   4,5,6,6, 6,6,4,5, 4,0,2,6, 0,1,6,6, 
+   3,3,3,6, 6,6,6,0, 3,3,3,3, 3,3,3,3, 
+   6,6,6,6, 1,1,1,1, 9,9,6,6, 6,6,6,6, 
+   6,0,6,6, 0,0,7,7, 0,0,0,0, 0,0,3,10},
+
+  // Two byte opcode (0F <op>
+  {3,6,3,3, 0,0,0,0, 0,0,6,0, 6,12,12,12,
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3,
+   6,6,6,6, 6,6,6,6, 3,3,3,3, 3,3,3,3,
+   0,0,0,0, 0,0,6,0, 6,6,6,6, 6,6,6,6,
+
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3,
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3,
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+   3,4,4,4, 3,3,3,0, 3,3,13,13, 3,3,3,3, 
+
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6,  // conditional 4 byte off jumps 
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+   0,0,0,3, 4,3,0,0, 3,3,6,3, 4,3,3,3,  // AA invalid on 64bit 
+   3,3,3,3, 3,3,3,3, 3,3,4,3, 3,3,3,3, 
+
+   3,3,4,3, 4,4,4,3, 3,3,3,3, 3,3,3,3, 
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,0},
+
+  // Three byte opcode (0F 38 <op>
+  {3,3,3,3, 3,3,3,3, 3,3,3,3, 6,6,6,6,
+   3,6,6,3, 3,3,3,3, 3,3,3,3, 3,3,3,6,
+   3,3,3,3, 3,3,6,3, 3,3,3,3, 3,3,3,3,
+   3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3,
+
+   3,3,6,6, 3,3,3,3, 6,6,6,6, 6,6,6,6,
+   3,3,3,3, 6,3,6,6, 3,3,3,3, 3,3,3,3,
+   6,6,6,6, 3,3,6,6, 6,6,6,6, 3,3,3,3, 
+   6,6,6,6, 3,6,6,6, 3,3,6,6, 6,6,6,6, 
+
+   3,3,3,6, 3,6,3,3, 6,6,6,6, 3,6,3,6, 
+   3,3,3,3, 6,6,3,3, 3,3,3,3, 3,3,3,3, 
+   3,6,3,6, 3,6,3,3, 3,3,3,3, 3,3,3,3, 
+   6,6,6,6, 3,3,3,3, 3,3,3,3, 3,3,3,3, 
+
+   6,6,6,6, 6,6,3,6, 6,6,6,6, 6,6,6,6, 
+   3,3,6,6, 3,3,6,6, 6,6,6,3, 3,3,3,3, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, 
+   3,3,3,3, 6,3,3,3, 6,6,6,6, 6,6,6,6},
+
+  // Three byte opcode (0F 3A <op>)
+  {4,4,4,3, 4,4,4,3, 4,4,4,4, 4,4,4,4,
+   6,6,6,6, 4,4,4,4, 4,4,6,6, 6,4,4,4,
+   4,4,4,6, 6,6,4,6, 6,6,6,6, 6,6,6,6,
+   6,6,6,6, 6,6,6,6, 4,4,6,6, 6,6,4,6,
+
+   4,4,4,6, 4,6,4,6, 4,4,3,3, 3,6,6,6,
+   6,6,4,6, 6,6,6,6, 6,6,6,6, 3,3,3,3,
+   4,4,4,4, 6,6,6,6, 3,3,3,3, 3,3,3,3, 
+   4,6,6,6, 6,6,4,6, 3,3,3,3, 3,3,3,3, 
+
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6, 
+
+   6,6,6,6, 6,6,6,6, 6,6,4,4, 6,6,6,6, 
+   6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,4, 
+   6,6,6,6, 6,6,4,6, 6,6,6,6, 6,6,6,6, 
+   4,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6}};
+
+class Instruction
+{
+  private:
+    // struct modRM to help finding out lenght of instruction
+    struct modRMBits {
+      unsigned char rm:3;
+      unsigned char reg:3;
+      unsigned char mod:2;
+    };
+    union modRMByte {
+      unsigned char encoded;
+      modRMBits     bits;
+    };
+
+    // vex1 byte is needed in som cases to determine which op code map is used.
+    struct vex1Bits {
+      unsigned char map:5;
+      unsigned char B:1;
+      unsigned char X:1;
+      unsigned char R:1;
+    };
+    union vex1Byte {
+      unsigned char encoded;
+      vex1Bits bits;
+    };
+
+    int immediate;
+    int length;
+    modRMByte modRM;
+    vex1Byte vex1;
+    unsigned patch;
+    int prologueSize;
+
+    int decodePrefix(unsigned char *insns);
+    void decodeOpcode(unsigned char *insns);
+    void evalModRM(unsigned char insns);
+    void makePatch();
+    void groupFF(unsigned char *insns);
+    void groupF6F7(unsigned char *insns);
+    void group3dNOW(unsigned char *insns);
+    void group0F00(unsigned char *insns);
+    void groupSSE5A(unsigned char *insns);
+ 
+  public:
+    Instruction();
+    void clear();
+    unsigned getPatch();
+    int decodeInstruction(const void *sym, int n);
+};
+#endif //INSTURCTION_H


### PR DESCRIPTION
The instruction length decoding is made in class. There are a lookup table where each instruction is grouped with similar instructions.

If the instruction is not yet supported or can not be moved instruction length is set to 0 and IgHook prints unrecognised prologue error.
