### PR TITLE
Control profiling at startup and at runtime

### DIFF
--- a/src/igprof
+++ b/src/igprof
@@ -21,6 +21,7 @@ usage() {
   echo -e "-pr, --real-time            \tmeasure real time in performance profiler"
   echo -e "-pu, --user-time            \tmeasure user time in performance profiler"
   echo -e "-pk, --keep-on-fork         \tdo not reset performance profile in fork child"
+  echo -e "-pd, --disable-on-start     \tdo not enable during startup"
   echo -e "-fd, --file-descriptor      \tstart the file descriptor profile"
   echo -e "-fp:malloc:LIB	       \tprofile cpu cycles spent in malloc like functions"
   echo -e "-fpi:FUNC:LIB	       \tprofile cpu cycles spent in function X which returns integer or pointer"
@@ -93,6 +94,8 @@ while [ "$#" != 0 ]; do
       [ -z "$PERF" ] && PERF="perf"; PERF="$PERF:user"; shift ;;
     -pk | --keep-on-fork )
       [ -z "$PERF" ] && PERF="perf"; PERF="$PERF:keep"; shift ;;
+    -pd | --disable-on-start )
+      [ -z "$PERF" ] && PERF="perf"; PERF="$PERF:nostart"; shift ;;
 
     -fp* )
       FP_MODE=$(echo $1 | cut -f1 -d: -s);

--- a/src/profile-perf.cc
+++ b/src/profile-perf.cc
@@ -122,6 +122,7 @@ initialize(void)
 
   const char    *options = igprof_options();
   bool          enable = false;
+  bool          enable_on_init = true;
 
   while (options && *options)
   {
@@ -156,6 +157,11 @@ initialize(void)
         {
           s_keep = true;
           options += 5;
+        }
+        else if (! strncmp(options, ":nostart", 8))
+        {
+          enable_on_init = false;
+          options += 8;
         }
         else
           break;
@@ -205,7 +211,8 @@ initialize(void)
 
   enableSignalHandler();
   enableTimer();
-  igprof_enable_globally();
+  if (enable_on_init)
+    igprof_enable_globally();
 }
 
 // -------------------------------------------------------------------

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -33,7 +33,7 @@ HIDDEN void             (*igprof_abort)(void) __attribute__((noreturn)) = &abort
 HIDDEN char *           (*igprof_getenv)(const char *) = &getenv;
 HIDDEN int              (*igprof_unsetenv)(const char *) = &unsetenv;
 HIDDEN bool             s_igprof_activated = false;
-HIDDEN IgProfAtomic     s_igprof_enabled = 0;
+       IgProfAtomic     s_igprof_enabled = 0;
 HIDDEN pthread_key_t    s_igprof_bufkey;
 HIDDEN pthread_key_t    s_igprof_flagkey;
 HIDDEN int              s_igprof_stderrOpen = true;

--- a/src/profile.h
+++ b/src/profile.h
@@ -37,14 +37,14 @@ igprof_buffer(void)
 }
 
 /** Enable the profiling system globally. Safe to call from anywhere. */
-HIDDEN inline void
+inline void
 igprof_enable_globally(void)
 {
   IgProfAtomicInc(&s_igprof_enabled);
 }
 
 /** Disable the profiling system globally. Safe to call from anywhere. */
-HIDDEN inline void
+inline void
 igprof_disable_globally(void)
 {
   IgProfAtomicDec(&s_igprof_enabled);


### PR DESCRIPTION
Add option to disable performance-prof at startup.
Export functions igprof_enable/disable_globally() that were previously hidden.
