### PR TITLE
tcmalloc syms

### DIFF
--- a/src/hook.cc
+++ b/src/hook.cc
@@ -311,8 +311,8 @@ findAndMapBinary(dl_phdr_info *info,
       // Get mapping parameters.
       int c;
       char prot[5];
-      unsigned long begin, end, offset;
-      long devmajor, devminor, inode;
+      long inode;
+      unsigned long begin, end, offset, devmajor, devminor;
       if (fscanf(maps, "%lx-%lx %4s %lx %lx:%lx %ld",
                  &begin, &end, prot, &offset,
                  &devmajor, &devminor, &inode)


### PR DESCRIPTION
Here are some changes for instrumenting any symbol in any linked shared object, including non-dynamically exported symbols. That support is then used to instrument tcmalloc, especially if it happens to be linked directly into the main binary.

This seems to work for us, but you might want to check this doesn't introduce any major start-up time regressions for binaries with gadjillion shared libraries linked in. Longer term I think it would make sense to expose this as an API out of IgHook and shift all instrumentation to work more on the pattern of "for all symbols matching name 'x': invoke callback which decides whether to allocate a hook, create a trampoline and instrument the function".