### PR TITLE
Suppress warning on unused noreturn attribute on a typedef

### DIFF
--- a/src/profile.cc
+++ b/src/profile.cc
@@ -29,7 +29,7 @@
 #endif
 
 // Global variables initialised once here.
-HIDDEN IgProfAbortFunc *igprof_abort = &abort;
+HIDDEN void             (*igprof_abort)(void) __attribute__((noreturn)) = &abort;
 HIDDEN char *           (*igprof_getenv)(const char *) = &getenv;
 HIDDEN int              (*igprof_unsetenv)(const char *) = &unsetenv;
 HIDDEN bool             s_igprof_activated = false;

--- a/src/profile.h
+++ b/src/profile.h
@@ -7,14 +7,21 @@
 # include <pthread.h>
 
 class IgProfTrace;
+#if __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wattributes"
+#endif
 typedef void IgProfAbortFunc (void) __attribute__((noreturn));
+#if __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 extern bool             s_igprof_activated;
 extern IgProfAtomic     s_igprof_enabled;
 extern pthread_key_t    s_igprof_bufkey;
 extern pthread_key_t    s_igprof_flagkey;
 extern int              s_igprof_stderrOpen;
-extern IgProfAbortFunc  *igprof_abort;
+extern void             (*igprof_abort) (void) __attribute__((noreturn));
 extern char *           (*igprof_getenv) (const char *);
 extern int              (*igprof_unsetenv) (const char *);
 


### PR DESCRIPTION
This should fix the travis build error introduced by earlier noreturn fix attempts. It's a bit delicate in that the typedef now ends up used in only one place, but seems to be a working compromise.