### PR TITLE
Make igprof compile on gcc < 4.6.

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -7,12 +7,12 @@
 # include <pthread.h>
 
 class IgProfTrace;
-#if __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wattributes"
 #endif
 typedef void IgProfAbortFunc (void) __attribute__((noreturn));
-#if __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 # pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
The diagnostic pragmas were introduced in GCC 4.6:

https://gcc.gnu.org/gcc-4.6/changes.html

this brings igprof back on vanilla slc5 and slc6 installations which
ship with ancient compilers.