### PR TITLE
Silence unused variable warning.

### DIFF
--- a/src/profile-calls.cc
+++ b/src/profile-calls.cc
@@ -358,4 +358,4 @@ dodoublelib(void *a, void *b, void *c, void *d, void *e, void *f)
 }
 
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/profile-empty.cc
+++ b/src/profile-empty.cc
@@ -344,4 +344,4 @@ dofree(IgHook::SafeData<igprof_dofree_t> &hook, void *ptr)
 }
 
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/profile-energy.cc
+++ b/src/profile-energy.cc
@@ -593,4 +593,5 @@ dofclose(IgHook::SafeData<igprof_dofclose_t> &hook, FILE * stream)
 }
 #endif
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+
+static bool autoboot __attribute__((used)) = (initialize(), true) ;

--- a/src/profile-fd.cc
+++ b/src/profile-fd.cc
@@ -251,4 +251,4 @@ doaccept(IgHook::SafeData<igprof_doaccept_t> &hook,
 }
 
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/profile-finstrument.cc
+++ b/src/profile-finstrument.cc
@@ -120,4 +120,4 @@ do_exit ()
     }
 }
 
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/profile-mem.cc
+++ b/src/profile-mem.cc
@@ -375,4 +375,4 @@ dodelsize(IgHook::SafeData<igprof_dodelsize_t> &hook, void *ptr, size_t n)
 }
 
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/trace-mem.cc
+++ b/src/trace-mem.cc
@@ -87,4 +87,4 @@ domalloc(IgHook::SafeData<igprof_domalloc_t> &hook, size_t size)
 }
 
 //////////////////////////////////////////////////////////////////////
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);

--- a/src/trace-mmap.cc
+++ b/src/trace-mmap.cc
@@ -477,4 +477,4 @@ dommap64(IgHook::SafeData<igprof_dommap64_t> &hook,
 }
 
 //////////////////////////////////////////////////////////////////////
-static bool autoboot = initialize();
+static bool autoboot __attribute__((used)) = initialize();

--- a/src/trace-throw.cc
+++ b/src/trace-throw.cc
@@ -172,4 +172,4 @@ dothrow(IgHook::SafeData<igprof_dothrow_t> &hook,
 }
 
 //////////////////////////////////////////////////////////////////////
-static bool autoboot = (initialize (), true);
+static bool autoboot __attribute__((used)) = (initialize (), true);


### PR DESCRIPTION
SLC6 default compiler (gcc 4.4.1) complains about the autoboot variable being
unused, since it's only needed to invoke the initialisation but not referred
anywhere. While the behavior is questionable and does not seem to be an issue
of different compilers, this makes sure that the complains are removed.