### PR TITLE
Silence unused variable warning (follow up)

### DIFF
--- a/src/profile-perf.cc
+++ b/src/profile-perf.cc
@@ -424,4 +424,4 @@ dofclose(IgHook::SafeData<igprof_dofclose_t> &hook, FILE * stream)
 }
 #endif
 // -------------------------------------------------------------------
-static bool autoboot = (initialize(), true);
+static bool autoboot __attribute__((used)) = (initialize(), true);


### PR DESCRIPTION
There is one more missed in ffa706ce2a4caacf9eef88dd45bc640b4aa56d13.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>