### PR TITLE
Resolve compilation errors with GCC 6.0.0 (r233941)

### DIFF
--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -4374,8 +4374,8 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
       else
         puts(",");
 
-      printf("[%d, %d, %d, %"PRId64", %"PRId64", %"PRId64", %"PRId64", "
-              "%"PRId64", %"PRId64", %"PRId64", ",
+      printf("[%d, %d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", %" PRId64 ", "
+              "%" PRId64 ", %" PRId64 ", %" PRId64 ", ",
                 mainRow.rank(), symbolIndex, fileIndex,
                 mainRow.SELF, mainRow.CUM, mainRow.KIDS,
                 mainRow.SELF_ALL[1], mainRow.CUM_ALL[1],
@@ -4445,7 +4445,7 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
           first = false;
         else
           puts(",");
-        printf("[%d, %d, %"PRId64", %"PRId64", %"PRId64", ",
+        printf("[%d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", ",
                mainRow.rank(), row.rank(),
                row.SELF_COUNTS, row.SELF_CALLS, row.SELF_PATHS);
 
@@ -4472,7 +4472,7 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
           first = false;
         else
           puts(",");
-        printf("[%d, %d, %"PRId64", %"PRId64", %"PRId64", ",
+        printf("[%d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", ",
                mainRow.rank(), row.rank(),
                row.SELF_COUNTS, row.SELF_CALLS, row.SELF_PATHS);
 


### PR DESCRIPTION
Whitespace around string literal is required.

Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>