### PR TITLE
Fix undercounting when using TBB resumable tasks.

### DIFF
--- a/src/profile-perf.cc
+++ b/src/profile-perf.cc
@@ -107,6 +107,9 @@ enableSignalHandler(void)
 static void
 threadInit(void)
 {
+  // check if someone else has installed a signal handler
+  struct sigaction sa;
+  if (!(sa.sa_handler == SIG_IGN || sa.sa_handler == SIG_DFL)) return;
   // Enable profiling in this thread.
   enableSignalHandler();
   enableTimer();

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -155,8 +155,8 @@ disposeTraceBuffer(IgProfTrace *buf)
     igprof_debug("merging profile buffer %p to master buffer %p\n",
                  (void *) buf, (void *) s_masterbuf);
     s_masterbuf->mergeFrom(*buf);
-    allTraceBuffers().erase(buf);
-    delete buf;
+//    allTraceBuffers().erase(buf);
+//    delete buf;
   }
 }
 
@@ -836,10 +836,10 @@ threadWrapper(void *arg)
 		   (unsigned long) pthread_self(),
 		   (void *) start_routine, start_arg);
 
-    itimerval stopped = { { 0, 0 }, { 0, 0 } };
-    setitimer(ITIMER_PROF, &stopped, 0);
-    setitimer(ITIMER_VIRTUAL, &stopped, 0);
-    setitimer(ITIMER_REAL, &stopped, 0);
+//    itimerval stopped = { { 0, 0 }, { 0, 0 } };
+//    setitimer(ITIMER_PROF, &stopped, 0);
+//    setitimer(ITIMER_VIRTUAL, &stopped, 0);
+//    setitimer(ITIMER_REAL, &stopped, 0);
   }
   return ret;
 }


### PR DESCRIPTION
Don't disable the profiling timer and don't delete the buffer when the start routine for the thread exits.

As discussed in https://github.com/igprof/igprof/issues/86 TBB resumable tasks use makecontext and swapcontext which somehow makes the main thread or the coroutine started by appear to exit. This triggers igprof to stop the profiling timer and merge and delete the associated buffer. Some combination of the two causes the under-reporting.