### PR TITLE
Handle sprintf depreation

### DIFF
--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -1209,12 +1209,12 @@ symlookup(FileInfo *file, int fileoff, std::string& symname, bool useGdb)
     char buffer[1024];
     if (file->NAME == "<dynamically generated>")
     {
-      sprintf(buffer, "@?0x%x{<dynamically-generated>}", fileoff);
+      snprintf(buffer, 1024, "@?0x%x{<dynamically-generated>}", fileoff);
       result = buffer;
     }
     else
     {
-      sprintf(buffer, "+%d}",fileoff);
+      snprintf(buffer, 1024, "+%d}",fileoff);
       // Finds the filename by looking up for the last / in the path
       // and picking up only the remaining.
       // Notice that this works also in the case / is not found
@@ -4072,7 +4072,7 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
       }
 
       char rankBuffer[256];
-      sprintf(rankBuffer, "[%d]", mainRow.rank());
+      snprintf(rankBuffer, 256, "[%d]", mainRow.rank());
       printf("%-8s", rankBuffer);
 
       if (m_showLocalityMetrics || m_showPageRanges)

--- a/src/analyse.h
+++ b/src/analyse.h
@@ -221,7 +221,7 @@ thousands(double value, int leftPadding, int decimalPositions)
   assert(decimalPositions < 63);
   char buffer[64];
   double decimal = fabs(value-int64_t(value));
-  sprintf(buffer+1, "%.2f", decimal);
+  snprintf(buffer+1, 63, "%.2f", decimal);
   buffer[decimalPositions+3] = 0;
   return result + &buffer[2];
 }
@@ -231,7 +231,7 @@ std::string
 toString(int64_t value)
 {
   char buffer[1024];
-  sprintf(buffer,"%" PRIi64, value);
+  snprintf(buffer, 1024, "%" PRIi64, value);
   return buffer;
 }
 
@@ -262,7 +262,7 @@ public:
     {
       printf("%*s", m_size, n.c_str());
       char denBuffer[256];
-      sprintf(denBuffer, " / %%-%ds", m_size);
+      snprintf(denBuffer, 256, " / %%-%ds", m_size);
       printf(denBuffer, d.c_str());
     }
 

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -199,7 +199,7 @@ dumpOneProfile(IgProfDumpInfo &info, IgProfTrace::Stack *frame)
 
       if (UNLIKELY(! symname || ! *symname))
       {
-        symlen = sprintf(symgen, "@?%p", sym->address);
+        symlen = snprintf(symgen, 32, "@?%p", sym->address);
         symname = symgen;
 	ASSERT(symlen <= sizeof(symgen));
       }
@@ -328,7 +328,7 @@ dumpAllProfiles(void *arg)
 
     timeval tv;
     gettimeofday(&tv, 0);
-    sprintf(outname, "|gzip -c>igprof.%.100s.%ld.%f.gz",
+    snprintf(outname, MAX_FNAME, "|gzip -c>igprof.%.100s.%ld.%f.gz",
             progname, (long) getpid(), tv.tv_sec + 1e-6*tv.tv_usec);
     tofile = outname;
   }
@@ -343,7 +343,7 @@ dumpAllProfiles(void *arg)
   else
   {
     char clockres[32];
-    size_t clockreslen = sprintf(clockres, "%f", s_clockres);
+    size_t clockreslen = snprintf(clockres, 32, "%f", s_clockres);
     size_t prognamelen = strlen(program_invocation_name);
     info->io.attach(fileno(info->output));
     info->io.put("P=(HEX ID=").put(getpid())

--- a/src/trace-mem.cc
+++ b/src/trace-mem.cc
@@ -75,7 +75,7 @@ domalloc(IgHook::SafeData<igprof_domalloc_t> &hook, size_t size)
     if (IgTrace::filter(0, stack, depth))
     {
       char buf[1024];
-      write(2, buf, sprintf(buf,
+      write(2, buf, snprintf(buf, 1024,
 			    "*** MALLOC %ld bytes => %p, by %.500s [thread %lu pid %ld]\n",
 			    (unsigned long) size, result, IgTrace::program(),
 			    (unsigned long) pthread_self(), (long) getpid()));

--- a/src/trace-mmap.cc
+++ b/src/trace-mmap.cc
@@ -342,7 +342,7 @@ munmapreport(void *addr, size_t len)
       char hexsym[32];
       if (! sym || ! *sym)
       {
-        sprintf(hexsym, "@?%p", symaddr);
+        snprintf(hexsym, 32, "@?%p", symaddr);
         sym = hexsym;
       }
       else if (s_demangle && sym[0] == '_' && sym[1] == 'Z')
@@ -402,7 +402,7 @@ mmapreport(const char *sz, void *addr, size_t len, int prot, int flags, int fd, 
       char hexsym[32];
       if (! sym || ! *sym)
       {
-        sprintf(hexsym, "@?%p", symaddr);
+        snprintf(hexsym, 32, "@?%p", symaddr);
         sym = hexsym;
       }
       else if (s_demangle && sym[0] == '_' && sym[1] == 'Z')

--- a/src/trace-throw.cc
+++ b/src/trace-throw.cc
@@ -103,7 +103,7 @@ dothrow(IgHook::SafeData<igprof_dothrow_t> &hook,
 	s_demanglehere = demangled;
     }
 
-    write(2, buf, sprintf(buf,
+    write(2, buf, snprintf(buf, 2048,
 			  "*** THROW by %.500s [thread %lu pid %ld]:\n"
 			  " Exception of type %.500s (address %p)\n",
 			  IgTrace::program(),
@@ -129,7 +129,7 @@ dothrow(IgHook::SafeData<igprof_dothrow_t> &hook,
       if (demangled && demangled != s_demanglehere)
 	s_demanglehere = demangled;
     }
-    write(2, buf, sprintf(buf, " Destructor %.500s (%p)\n Stack:\n",
+    write(2, buf, snprintf(buf, 2048, " Destructor %.500s (%p)\n Stack:\n",
 			  (sym ? sym : "unknown function"),
 			  __extension__ (void *) dest));
 
@@ -143,7 +143,7 @@ dothrow(IgHook::SafeData<igprof_dothrow_t> &hook,
       char hexsym[32];
       if (! sym || ! *sym)
       {
-	sprintf(hexsym, "@?%p", symaddr);
+	snprintf(hexsym, 32, "@?%p", symaddr);
 	sym = hexsym;
       }
       else if (s_demangle)
@@ -158,7 +158,7 @@ dothrow(IgHook::SafeData<igprof_dothrow_t> &hook,
       if (! lib)
 	lib = "<unknown library>";
 
-      write(2, buf, sprintf(buf,
+      write(2, buf, snprintf(buf, 2048,
 			    "  %3d: %-10p %.500s %s %ld [%.500s %s %ld]\n",
 			    i-1, stack[i], sym, (symoff < 0 ? "-" : "+"),
 			    labs(symoff), lib, (liboff < 0 ? "-" : "+"),


### PR DESCRIPTION
sprintf is marked as deprecated under XCode 13, resulting in compiler errors due to the stricted options we use.

We move everything to use snprintf to silence the warning and maybe avoid some buffer overrun.