### PR TITLE
Add aligned_alloc for memory profiling which was added with the C11 standard.

### DIFF
--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -1020,7 +1020,7 @@ public:
   MallocFilter(bool isMax)
   :m_isMax(isMax)
   {
-    m_filter = "malloc", "calloc", "realloc", "memalign", "posix_memalign",
+    m_filter = "malloc", "calloc", "realloc", "memalign", "posix_memalign", "aligned_alloc",
                "valloc", "zmalloc", "zcalloc", "zrealloc", "_Znwj", "_Znwm",
                "_Znaj", "_Znam";
   }

--- a/src/profile-calls.cc
+++ b/src/profile-calls.cc
@@ -26,6 +26,9 @@ DUAL_HOOK(3, int, dopmemalign, _main, _libc,
 DUAL_HOOK(2, void *, domemalign, _main, _libc,
           (size_t alignment, size_t size), (alignment, size),
           "memalign", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
+DUAL_HOOK(2, void *, doaligned_alloc, _main, _libc,
+          (size_t alignment, size_t size), (alignment, size),
+          "aligned_alloc", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
 DUAL_HOOK(1, void *, dovalloc, _main, _libc,
           (size_t size), (size),
           "valloc", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
@@ -159,6 +162,7 @@ initialize(void)
     IgHook::hook(dorealloc_hook_main.raw);
     IgHook::hook(dopmemalign_hook_main.raw);
     IgHook::hook(domemalign_hook_main.raw);
+    IgHook::hook(doaligned_alloc_hook_main.raw);
     IgHook::hook(dovalloc_hook_main.raw);
   }
   else if (trace_other)
@@ -172,6 +176,7 @@ initialize(void)
     if (domalloc_hook_main.raw.chain)    IgHook::hook(domalloc_hook_libc.raw);
     if (docalloc_hook_main.raw.chain)    IgHook::hook(docalloc_hook_libc.raw);
     if (domemalign_hook_main.raw.chain)  IgHook::hook(domemalign_hook_libc.raw);
+    if (doaligned_alloc_hook_main.raw.chain)  IgHook::hook(doaligned_alloc_hook_libc.raw);
     if (dovalloc_hook_main.raw.chain)    IgHook::hook(dovalloc_hook_libc.raw);
   }
   else if (trace_other)
@@ -240,6 +245,23 @@ dorealloc(IgHook::SafeData<igprof_dorealloc_t> &hook, void *ptr, size_t n)
 
 static void *
 domemalign(IgHook::SafeData<igprof_domemalign_t> &hook, size_t alignment, size_t size)
+{
+  bool enabled = igprof_disable();
+  uint64_t tstart, tend;
+
+  RDTSC(tstart);
+  void *result = (*hook.chain)(alignment, size);
+  RDTSC(tend);
+
+  if (LIKELY(enabled))
+    add(tend-tstart);
+
+  igprof_enable();
+  return result;
+}
+
+static void *
+doaligned_alloc(IgHook::SafeData<igprof_doaligned_alloc_t> &hook, size_t alignment, size_t size)
 {
   bool enabled = igprof_disable();
   uint64_t tstart, tend;

--- a/src/profile-empty.cc
+++ b/src/profile-empty.cc
@@ -26,6 +26,9 @@ DUAL_HOOK(3, int, dopmemalign, _main, _libc,
 DUAL_HOOK(2, void *, domemalign, _main, _libc,
           (size_t alignment, size_t size), (alignment, size),
           "memalign", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
+DUAL_HOOK(2, void *, doaligned_alloc, _main, _libc,
+          (size_t alignment, size_t size), (alignment, size),
+          "aligned_alloc", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
 DUAL_HOOK(1, void *, dovalloc, _main, _libc,
           (size_t size), (size),
           "valloc", 0, igprof_getenv("IGPROF_MALLOC_LIB"))
@@ -211,12 +214,13 @@ initialize(void)
   IgHook::hook(dorealloc_hook_main.raw);
   IgHook::hook(dopmemalign_hook_main.raw);
   IgHook::hook(domemalign_hook_main.raw);
+  IgHook::hook(doaligned_alloc_hook_main.raw);
   IgHook::hook(dovalloc_hook_main.raw);
   IgHook::hook(dofree_hook_main.raw);
 #if __linux
   if (domalloc_hook_main.raw.chain)    IgHook::hook(domalloc_hook_libc.raw);
   if (docalloc_hook_main.raw.chain)    IgHook::hook(docalloc_hook_libc.raw);
-  if (domemalign_hook_main.raw.chain)  IgHook::hook(domemalign_hook_libc.raw);
+  if (doaligned_alloc_hook_main.raw.chain)  IgHook::hook(doaligned_alloc_hook_libc.raw);
   if (dovalloc_hook_main.raw.chain)    IgHook::hook(dovalloc_hook_libc.raw);
   if (dofree_hook_main.raw.chain)      IgHook::hook(dofree_hook_libc.raw);
 #endif
@@ -287,6 +291,22 @@ dorealloc(IgHook::SafeData<igprof_dorealloc_t> &hook, void *ptr, size_t n)
 
 static void *
 domemalign(IgHook::SafeData<igprof_domemalign_t> &hook, size_t alignment, size_t size)
+{
+  bool enabled = igprof_disable();
+  void *result = (*hook.chain)(alignment, size);
+
+  if (LIKELY(enabled && result))
+  {
+    if (s_init_memory) memset(result, MAGIC_BYTE, size);
+    add(result, size);
+  }
+
+  igprof_enable();
+  return result;
+}
+
+static void *
+doaligned_alloc(IgHook::SafeData<igprof_doaligned_alloc_t> &hook, size_t alignment, size_t size)
 {
   bool enabled = igprof_disable();
   void *result = (*hook.chain)(alignment, size);


### PR DESCRIPTION
This might solve the problem CMS has encountered with Igprof memory profiling undercounting the amount of MEM_LIVE on RHEL8.