### PR TITLE
Fix the build with GCC 16 / Clang 22

### DIFF
--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -2065,13 +2065,11 @@ public:
     // FIXME: Add a new node called "others" to the list
     //        with the aggregated sum.
     int lastPrinted = -1;
-    // float others = 0.;
     for (size_t i = 0, e = node->CHILDREN.size(); i != e; i++)
     {
       Counter &childCounter = node->CHILDREN[i]->COUNTER;
       float childPct = percent(childCounter.ccnt, m_totals);
       if ((childPct < 1. && pct < 1.) || childPct < 0.1) {}
-        // others += childPct;
       else
         lastPrinted++;
     }

--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -3239,7 +3239,7 @@ std::ostream & operator<<(std::ostream &stream, OtherGProfRow& row)
 template <int ORDER>
 struct CompareCallersRow
 {
-  bool operator()(OtherGProfRow *a, OtherGProfRow *b)
+  bool operator()(OtherGProfRow *a, OtherGProfRow *b) const
     {
       int64_t callsDiff = ORDER * (a->SELF_COUNTS - b->SELF_COUNTS);
       int64_t cumDiff = ORDER * (a->CHILDREN_COUNTS - b->CHILDREN_COUNTS);

--- a/src/analyse.cc
+++ b/src/analyse.cc
@@ -2065,13 +2065,13 @@ public:
     // FIXME: Add a new node called "others" to the list
     //        with the aggregated sum.
     int lastPrinted = -1;
-    float others = 0.;
+    // float others = 0.;
     for (size_t i = 0, e = node->CHILDREN.size(); i != e; i++)
     {
       Counter &childCounter = node->CHILDREN[i]->COUNTER;
       float childPct = percent(childCounter.ccnt, m_totals);
-      if ((childPct < 1. && pct < 1.) || childPct < 0.1)
-        others += childPct;
+      if ((childPct < 1. && pct < 1.) || childPct < 0.1) {}
+        // others += childPct;
       else
         lastPrinted++;
     }

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -501,7 +501,7 @@ igprof_init(const char *id, void (*threadinit)(void), bool perthread, double clo
   if (void *libc = dlopen("libc.so.6", RTLD_LAZY | RTLD_GLOBAL))
   {
     if (void *sym = dlsym(libc, "abort"))
-      igprof_abort = __extension__ (IgProfAbortFunc *) sym;
+      igprof_abort = __extension__ (void (*)(void) throw()) sym;
 
     if (void *sym = dlsym(libc, "getenv"))
       igprof_getenv = __extension__ (char *(*)(const char *)) sym;


### PR DESCRIPTION
Fix 
``` cpp
/igprof/src/profile.cc:504:22: error: incompatible function pointer types assigning to 'void (*)() throw()' from 'IgProfAbortFunc *' (aka 'void (*)() __attribute__((noreturn))')
  504 |       igprof_abort = __extension__ (IgProfAbortFunc *) sym;
```

by changing the cast to match the declared type of `igprof_abort`, and 

``` c++
/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/stl_tree.h:1402:6: error: static assertion failed due to requirement 'std::__is_invocable<const CompareCallersRow<-1> &, OtherGProfRow *const &, OtherGProfRow *const &>::value': comparison object must be invocable with arguments of key_type
 1402 |             __is_invocable<const _Compare&, const _Key&, const _Key&>::value,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/stl_tree.h:2811:13: note: in instantiation of function template specialization 'std::_Rb_tree<OtherGProfRow *, OtherGProfRow *, std::_Identity<OtherGProfRow *>, CompareCallersRow<-1>>::_M_key_compare<OtherGProfRow *, OtherGProfRow *>' requested here
 2811 |           __comp = _M_key_compare(__k, _S_key(__x));
      |                    ^
/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/stl_tree.h:2913:4: note: in instantiation of member function 'std::_Rb_tree<OtherGProfRow *, OtherGProfRow *, std::_Identity<OtherGProfRow *>, CompareCallersRow<-1>>::_M_get_insert_unique_pos' requested here
 2913 |         = _M_get_insert_unique_pos(_KeyOfValue()(__v));
      |           ^
/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/stl_set.h:537:9: note: in instantiation of function template specialization 'std::_Rb_tree<OtherGProfRow *, OtherGProfRow *, std::_Identity<OtherGProfRow *>, CompareCallersRow<-1>>::_M_insert_unique<OtherGProfRow *const &>' requested here
  537 |           _M_t._M_insert_unique(__x);
      |                ^
/igprof/src/analyse.cc:3386:20: note: in instantiation of member function 'std::set<OtherGProfRow *, CompareCallersRow<-1>>::insert' requested here
 3386 |       m_row->CALLS.insert(callrow);
      |                    ^
```
adding a `const` for `CompareCallersRow::operator()`